### PR TITLE
Update README files for multi-folder Google Drive support

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -86,7 +86,8 @@ GASエディタの「プロジェクトの設定 (歯車アイコン)」 \> 「�
 | GEMINI\_MODEL\_NAME | ✅ | gemini-1.5-pro (使用するGeminiモデル名) |
 | DRIVE\_JSON\_FILE\_IDS | △ | JSON配列形式 (下記参照) - 推奨 |
 | DRIVE\_JSON\_FILE\_ID | △ | 1A2b3C... (単一ファイルID、後方互換用) |
-| DRIVE\_FOLDER\_ID | △ | 1FolderID... (フォルダ再帰探索用 - Issue #30) |
+| DRIVE\_FOLDER\_ID | △ | id1,id2,... (フォルダ再帰探索用 - カンマ区切りで複数指定可) |
+| RESUME\_CACHE\_FOLDER\_ID | | Resumeの状態ファイルを保存するフォルダID |
 
 **△注意**: `DRIVE_JSON_FILE_IDS`、`DRIVE_JSON_FILE_ID`、`DRIVE_FOLDER_ID` のいずれか1つ以上が必須です。
 
@@ -110,9 +111,14 @@ GASエディタの「プロジェクトの設定 (歯車アイコン)」 \> 「�
 #### **フォルダ再帰探索 (DRIVE\_FOLDER\_ID) - Issue #30 新機能**
 
 指定したGoogle Driveフォルダ以下を再帰的に探索し、条件を満たすMCP設定ファイルを自動検出します。
+**カンマ区切りで複数のフォルダIDを指定可能**です。
 
 ```
+# 単一フォルダ
 DRIVE_FOLDER_ID=1FolderID_Here
+
+# 複数フォルダ（カンマ区切り）
+DRIVE_FOLDER_ID=1FolderA,1FolderB,1FolderC
 ```
 
 **フィルタリング条件**:
@@ -133,9 +139,27 @@ DRIVE_FOLDER_ID=1FolderID_Here
 # 個別ファイルとフォルダの併用
 DRIVE_JSON_FILE_IDS=[{"name": "Default", "id": "1ABC..."}]
 DRIVE_FOLDER_ID=1FolderID_Here
+
+# 複数フォルダの併用
+DRIVE_JSON_FILE_IDS=[{"name": "Default", "id": "1ABC..."}]
+DRIVE_FOLDER_ID=1FolderA,1FolderB,1FolderC
 ```
 
-この設定では、まず `1ABC...` のファイルを読み込み、その後 `1FolderID_Here` フォルダ内の有効なJSONファイルを全て探索してマージします。
+この設定では、まず明示的に指定したファイルを読み込み、その後指定した全フォルダ内の有効なJSONファイルを探索してマージします。
+
+#### **Resume用キャッシュフォルダ (RESUME\_CACHE\_FOLDER\_ID)**
+
+GASの実行時間制限（6分）対策のResume機能で使用する状態ファイルの保存先フォルダを指定します。
+
+```
+RESUME_CACHE_FOLDER_ID=1CacheFolderID
+```
+
+* **未設定の場合**: Google Driveのルートフォルダに一時ファイルが保存されます
+* **設定時**: 指定フォルダに `kamui_scan_state_temp.json` や `kamui_session_data.json` が保存されます
+* **フォルダ未アクセス時**: フォールバックとしてルートフォルダに保存
+
+**推奨**: 一時ファイルの整理が容易になるため、専用フォルダを作成して設定することを推奨します。
 
 ### **4.4. 初回実行と権限承認**
 
@@ -237,3 +261,4 @@ DRIVE_FOLDER_ID=1FolderID_Here
 *Updated: 2025-12-02 (Issue #23 対応)*
 *Updated: 2025-12-06 (Issue #26 マルチソースJSON対応)*
 *Updated: 2025-12-17 (Issue #30 フォルダ再帰探索機能追加)*
+*Updated: 2026-01-21 (複数フォルダID対応、RESUME\_CACHE\_FOLDER\_ID追加)*

--- a/tools/crawler/README.md
+++ b/tools/crawler/README.md
@@ -32,7 +32,7 @@ cp .env.example .env
 | :---- | :---- | :---- |
 | DRIVE\_FILE\_IDS | 任意 | JSON配列形式の個別ファイルID設定（推奨） |
 | DRIVE\_FILE\_ID | 任意 | 単一ファイルID（後方互換用） |
-| DRIVE\_FOLDER\_ID | 任意 | 監視対象のルートフォルダID（再帰探索） |
+| DRIVE\_FOLDER\_ID | 任意 | 監視対象フォルダID（カンマ区切りで複数指定可、再帰探索） |
 | GOOGLE\_API\_KEY | DRIVE\_FOLDER\_ID使用時必須 | Google Drive API キー |
 
 **注意**: `DRIVE_FILE_IDS`/`DRIVE_FILE_ID` と `DRIVE_FOLDER_ID` は併用可能です。両方設定した場合、明示的なファイルIDの設定が先に読み込まれ、フォルダスキャンの結果がマージされます（後勝ち）。
@@ -53,11 +53,16 @@ DRIVE_FILE_IDS=[{"name": "Legacy", "id": "1ABC..."}, {"name": "Latest", "id": "1
 #### **フォルダ再帰探索形式（Issue #30 新機能）**
 
 ```bash
+# 単一フォルダ
 DRIVE_FOLDER_ID=1FolderID_Here
+GOOGLE_API_KEY=AIzaSy...
+
+# 複数フォルダ（カンマ区切り）
+DRIVE_FOLDER_ID=1FolderA,1FolderB,1FolderC
 GOOGLE_API_KEY=AIzaSy...
 ```
 
-指定したフォルダ以下を再帰的に探索し、以下の条件を満たすJSONファイルを自動検出します:
+指定した全フォルダを再帰的に探索し、以下の条件を満たすJSONファイルを自動検出します:
 
 | フィルタ条件 | 説明 |
 | :---- | :---- |
@@ -141,7 +146,7 @@ python main.py \--merge
 | :---- | :---- | :---- |
 | DRIVE\_FILE\_IDS | 任意 | JSON配列形式のファイル設定（推奨） |
 | DRIVE\_FILE\_ID | 任意 | Google DriveファイルのID（後方互換用） |
-| DRIVE\_FOLDER\_ID | 任意 | 監視対象のルートフォルダID |
+| DRIVE\_FOLDER\_ID | 任意 | 監視対象フォルダID（カンマ区切りで複数指定可） |
 | GOOGLE\_API\_KEY | フォルダ探索時必須 | Google Drive API キー |
 | KAMUI\_CODE\_PASS\_KEY | 推奨 | Kamui Code MCPサーバー認証用パスキー |
 
@@ -461,3 +466,4 @@ python main.py \--timeout 120 \--max-concurrent 5
 *Updated: 2025-12-26 (KAMUI\_CODE\_PASS\_KEY パスキー認証対応)*
 *Updated: 2025-12-26 (パスキーローカルテストツール追加)*
 *Updated: 2025-12-26 (Windowsでのテスト手順を追加)*
+*Updated: 2026-01-21 (DRIVE\_FOLDER\_IDの複数フォルダ対応)*


### PR DESCRIPTION
- tools/README.md:
  - DRIVE_FOLDER_ID now supports comma-separated multiple folder IDs
  - Add RESUME_CACHE_FOLDER_ID documentation for controlling state file location
  - Update usage examples for multiple folders

- tools/crawler/README.md:
  - Update DRIVE_FOLDER_ID description for comma-separated multiple folder support
  - Update folder recursive scan section with multiple folder examples