### PR TITLE
fix(release): add release:created trigger for manual releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - 'v*'
+  release:
+    types: [created]
 
 jobs:
   release:
@@ -17,7 +19,16 @@ jobs:
 
       - name: Get version from tag
         id: version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+        run: |
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "VERSION=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
+          else
+            echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Checkout release tag
+        if: github.event_name == 'release'
+        run: git checkout ${{ github.event.release.tag_name }}
 
       - name: Create Release ZIP
         run: |


### PR DESCRIPTION
## Summary
- GitHub UIから手動でリリースを作成した場合にもZIP添付ワークフローが発火するよう `release: types: [created]` トリガーを追加
- `release` イベント時はタグ名の取得方法が異なるため、`github.event.release.tag_name` から取得するよう分岐を追加
- `release` イベント時は該当タグをcheckoutするステップを追加

## Background
v1.4.0 が手動リリースで作成されたため、`push tags` トリガーが発火せずZIPアセットが添付されなかった。この修正により、今後は手動リリースでもZIPが自動生成される。

## Test plan
- [ ] このPRをマージ後、v1.4.0タグを再pushしてZIPが正しく生成されることを確認（A-1手順）
- [ ] 次回リリース時に手動作成・タグpushどちらでもZIPが添付されることを確認

https://claude.ai/code/session_018kvDFeE2vbh77sK7HrT7TM