### PR TITLE
security: add SRI hashes to CDN scripts

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>kamuicode MCP Tool List</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/js-yaml/4.1.0/js-yaml.min.js"></script>
+    <script src="https://cdn.tailwindcss.com/3.4.17" integrity="sha384-igm5BeiBt36UU4gqwWS7imYmelpTsZlQ45FZf+XBn9MuJbn4nQr7yx1yFydocC/K" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/js-yaml/4.1.0/js-yaml.min.js" integrity="sha384-+pxiN6T7yvpryuJmE1gM9PX7yQit15auDb+ZwwvJOd/4be2Cie5/IuVXgQb/S9du" crossorigin="anonymous"></script>
     <style>
         @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
         body { font-family: 'Inter', sans-serif; }

--- a/kamuicode-config-manager.html
+++ b/kamuicode-config-manager.html
@@ -5,13 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>kamuicode Config Manager</title>
     <!-- Tailwind CSS CDN -->
-    <script src="https://cdn.tailwindcss.com"></script>
+    <script src="https://cdn.tailwindcss.com/3.4.17" integrity="sha384-igm5BeiBt36UU4gqwWS7imYmelpTsZlQ45FZf+XBn9MuJbn4nQr7yx1yFydocC/K" crossorigin="anonymous"></script>
     <!-- js-yaml CDN (YAMLパーサー) -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/js-yaml/4.1.0/js-yaml.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/js-yaml/4.1.0/js-yaml.min.js" integrity="sha384-+pxiN6T7yvpryuJmE1gM9PX7yQit15auDb+ZwwvJOd/4be2Cie5/IuVXgQb/S9du" crossorigin="anonymous"></script>
     <!-- Alpine.js Collapse Plugin (アコーディオンアニメーション) -->
-    <script src="https://cdn.jsdelivr.net/npm/@alpinejs/collapse@3.14.1/dist/cdn.min.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/@alpinejs/collapse@3.14.1/dist/cdn.min.js" integrity="sha384-NArNwzWsUSF+kY2lgW4YriEkjLqi+J+za6HrENUn/3nZqkBnWbxV22kCJEK5Uu6n" crossorigin="anonymous" defer></script>
     <!-- Alpine.js CDN (リアクティブUI) -->
-    <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.14.1/dist/cdn.min.js" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.14.1/dist/cdn.min.js" integrity="sha384-l8f0VcPi/M1iHPv8egOnY/15TDwqgbOR1anMIJWvU6nLRgZVLTLSaNqi/TOoT5Fh" crossorigin="anonymous" defer></script>
     <style>
         /* Interフォントの読み込み */
         @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');


### PR DESCRIPTION
## Summary
- 全CDNスクリプトに SRI (Subresource Integrity) ハッシュと `crossorigin="anonymous"` を追加
- Tailwind CSS を v3.4.17 にピン留め（未バージョンURLは動的リダイレクトのためSRI不可）
- Google Fonts はUA依存レスポンスのため対象外

## 対象リソース
| ライブラリ | ファイル |
|-----------|---------|
| Tailwind CSS 3.4.17 | 両方 |
| js-yaml 4.1.0 | 両方 |
| Alpine.js 3.14.1 | `kamuicode-config-manager.html` |
| Alpine.js Collapse 3.14.1 | `kamuicode-config-manager.html` |

## Test plan
- [ ] `kamuicode-config-manager.html` をブラウザで開き、UIが正常に動作すること
- [ ] `docs/index.html` をブラウザで開き、モデル一覧が正常に表示されること
- [ ] ブラウザのDevToolsコンソールにSRI関連エラーがないこと

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)