### PR TITLE
fix: remove SRI from local HTML (file:// incompatible)

### DIFF
--- a/kamuicode-config-manager.html
+++ b/kamuicode-config-manager.html
@@ -5,13 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>kamuicode Config Manager</title>
     <!-- Tailwind CSS CDN -->
-    <script src="https://cdn.tailwindcss.com/3.4.17" integrity="sha384-igm5BeiBt36UU4gqwWS7imYmelpTsZlQ45FZf+XBn9MuJbn4nQr7yx1yFydocC/K" crossorigin="anonymous"></script>
+    <script src="https://cdn.tailwindcss.com/3.4.17"></script>
     <!-- js-yaml CDN (YAMLパーサー) -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/js-yaml/4.1.0/js-yaml.min.js" integrity="sha384-+pxiN6T7yvpryuJmE1gM9PX7yQit15auDb+ZwwvJOd/4be2Cie5/IuVXgQb/S9du" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/js-yaml/4.1.0/js-yaml.min.js"></script>
     <!-- Alpine.js Collapse Plugin (アコーディオンアニメーション) -->
-    <script src="https://cdn.jsdelivr.net/npm/@alpinejs/collapse@3.14.1/dist/cdn.min.js" integrity="sha384-NArNwzWsUSF+kY2lgW4YriEkjLqi+J+za6HrENUn/3nZqkBnWbxV22kCJEK5Uu6n" crossorigin="anonymous" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/@alpinejs/collapse@3.14.1/dist/cdn.min.js" defer></script>
     <!-- Alpine.js CDN (リアクティブUI) -->
-    <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.14.1/dist/cdn.min.js" integrity="sha384-l8f0VcPi/M1iHPv8egOnY/15TDwqgbOR1anMIJWvU6nLRgZVLTLSaNqi/TOoT5Fh" crossorigin="anonymous" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/alpinejs@3.14.1/dist/cdn.min.js" defer></script>
     <style>
         /* Interフォントの読み込み */
         @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');


### PR DESCRIPTION
## Summary
- `kamuicode-config-manager.html` からSRI属性を除去（ローカル `file://` で CORS エラーになるため）
- `docs/index.html`（GitHub Pages用）のSRIは維持

## Background
`crossorigin="anonymous"` + SRI は HTTPS 配信時のみ有効。`file://` プロトコルでは CORS エラーとなり、Tailwind CSS 等が読み込まれずデザインが崩れていた。

## Test plan
- [ ] `kamuicode-config-manager.html` をローカルで開きデザインが正常なこと
- [ ] GitHub Pages (`docs/index.html`) が引き続き正常に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)