### PR TITLE
fix: text filter crash when model fields are undefined

### DIFF
--- a/kamuicode-config-manager.html
+++ b/kamuicode-config-manager.html
@@ -613,9 +613,9 @@
                     this.filteredList = this.masterList.filter(model => {
                         const categoryMatch = !category || model.category === category;
                         const textMatch = !text ||
-                                          model.name.toLowerCase().includes(text) ||
-                                          (model.features && model.features.toLowerCase().includes(text)) || // featuresがnullでないかチェック
-                                          model.server_name.toLowerCase().includes(text);
+                                          (model.name && model.name.toLowerCase().includes(text)) ||
+                                          (model.features && model.features.toLowerCase().includes(text)) ||
+                                          (model.server_name && model.server_name.toLowerCase().includes(text));
                         return categoryMatch && textMatch;
                     });
 


### PR DESCRIPTION
## Summary
- `applyFilters()` のテキスト絞り込みで `model.name` / `model.server_name` が undefined の場合に `toLowerCase()` でクラッシュしていたのを修正
- `model.features` と同様のnullガードを追加

## Root Cause
JSONデータ内に `name` や `server_name` が未定義のモデルが存在すると、テキスト入力時に `TypeError: Cannot read properties of undefined` が発生し、フィルタが一切機能しなくなっていた。

## Test plan
- [ ] テキスト絞り込みで文字入力すると正常にフィルタされること
- [ ] カテゴリ絞り込みが引き続き正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)