### PR TITLE
fix(ci): upgrade GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,16 +23,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: 'docs'
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get version from tag
         id: version

--- a/.github/workflows/update_catalog.yml
+++ b/.github/workflows/update_catalog.yml
@@ -34,10 +34,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
           cache: 'pip'


### PR DESCRIPTION
Closes #67

## Summary
- Node.js 20 が非推奨となり、2026年6月2日にNode.js 24が強制デフォルトになるため、全GitHub Actionsを最新メジャーバージョンに更新
- `actions/checkout` v4→v6, `actions/configure-pages` v4→v6, `actions/upload-pages-artifact` v3→v4, `actions/deploy-pages` v4→v5, `actions/setup-python` v5→v6
- `softprops/action-gh-release@v2` は最新のため据え置き

## axios サプライチェーン攻撃の影響調査
2026年3月31日のaxios npm侵害について調査済み。**影響なし**:
- このリポジトリはnpm/axiosを一切使用していない（Pythonのaiohttp + GASのUrlFetchApp）
- 攻撃時間帯（00:21〜03:15 UTC）にワークフロー実行なし（最も近い実行は13:32 UTC）
- GitHub-hostedランナー（エフェメラル）を使用、セルフホストなし

## Test plan
- [ ] マージ後に Pages デプロイが正常に動作すること（push トリガーで自動実行）
- [ ] update_catalog を workflow_dispatch (dry_run: true) で手動実行し成功すること
- [ ] 次回リリース時に release.yml が正常動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)