### PR TITLE
fix: テキスト絞込バグ修正 + YAMLスキーマ検証導入

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,33 @@
+name: Validate YAML Schema
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'kamuicode_model_memo.yaml'
+      - 'tools/validate_model_memo.py'
+      - '.github/workflows/validate.yml'
+  pull_request:
+    paths:
+      - 'kamuicode_model_memo.yaml'
+      - 'tools/validate_model_memo.py'
+      - '.github/workflows/validate.yml'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+
+      - name: Install PyYAML
+        run: pip install pyyaml
+
+      - name: Validate kamuicode_model_memo.yaml
+        run: python tools/validate_model_memo.py

--- a/docs/index.html
+++ b/docs/index.html
@@ -170,8 +170,8 @@
                 const matchesCategory = category === '' || model.category === category;
                 const matchesPeriod = period === '' || (model.release_date && model.release_date.includes(period));
                 const matchesSearch = query === '' ||
-                    model.name.toLowerCase().includes(query) ||
-                    model.server_name.toLowerCase().includes(query) ||
+                    (model.name && model.name.toLowerCase().includes(query)) ||
+                    (model.server_name && model.server_name.toLowerCase().includes(query)) ||
                     (model.features && model.features.toLowerCase().includes(query));
 
                 return matchesCategory && matchesPeriod && matchesSearch;

--- a/kamuicode_model_memo.yaml
+++ b/kamuicode_model_memo.yaml
@@ -979,11 +979,10 @@ ai_models:
       server_name: i2v-kamui-fal-ltx-2-19b-image-to-video
       release_date: 2026年1月6日
       features: "(Lightricks) 4K解像度・50fpsでの生成が可能な19Bパラメータのオープンソース動画生成モデル。画像からの動画生成に加え、音声の同期生成にも対応。"
-    - model_name: Wan v2.6 Image-to-Video Flash
+    - name: Wan v2.6 Image-to-Video Flash
       server_name: i2v-kamui-wan-v26-image-to-video-flash
       release_date: 2025年12月16日
-      developer: Alibaba
-      url: https://kamui-code.ai/i2v/fal/wan/v2.6/image-to-video/flash
+      features: "(Alibaba) Wan v2.6 Image-to-Videoの高速版（Flash）。画像から動画への変換に最適化。"
     - name: Pixverse V5.6 Transition
       server_name: i2v-kamui-pixverse-v5-6-transition
       release_date: 2026年1月28日
@@ -1350,10 +1349,10 @@ ai_models:
       server_name: r2v-kamui-kling-video-v26-standard-motion-control
       release_date: 2025年12月3日
       features: "(Kuaishou) 参照動画の動きを参照画像のキャラクターに転写するMotion Control機能のv2.6標準モデル。画像と動画の向き（Orientation）を制御可能で、ダンスやジェスチャーの転写に適しており、コストパフォーマンスに優れる。"
-    - model: Vidu Q2 Reference-to-Video Pro
+    - name: Vidu Q2 Reference-to-Video Pro
       server_name: r2v-kamui-vidu-q2-reference-to-video-pro
       release_date: 2025年10月21日
-      developer: ShengShu Technology
+      features: "(ShengShu Technology) Vidu Q2のReference-to-Video Pro版。参照画像を用いた高品質な動画生成。"
     - name: Kling Video O3 Pro
       server_name: r2v-kamui-kling-video-o3-pro-reference-to-video
       release_date: 2026年2月4日
@@ -1810,11 +1809,10 @@ ai_models:
       release_date: 2026年1月13日
       features: "(Yatharth Sharma) わずか52KBという超軽量かつ高速な音声超解像モデル。16kHzの音声を48kHzにアップサンプリングし、TTSの出力や低品質な音声データの明瞭度を劇的に向上させる。"
 
-    - model_name: ElevenLabs Voice Changer (Speech to Speech)
+    - name: ElevenLabs Voice Changer (Speech to Speech)
       server_name: a2a-kamui-elevenlabs-voice-changer
       release_date: 2023年11月23日
-      description: ElevenLabsのSpeech to Speech（STS）機能。オーディオファイルの声を別の声に変換する。
-      url: https://elevenlabs.io/voice-changer
+      features: "(ElevenLabs) Speech to Speech（STS）機能。オーディオファイルの声を別の声に変換する。"
   image_audio_to_video:
     - name: LongCat Avatar (LongCat-Video-Avatar)
       server_name: ia2v-kamui-fal-longcat-multi-avatar

--- a/tools/code.js
+++ b/tools/code.js
@@ -1261,7 +1261,7 @@ ${categoryList}
 
 IMPORTANT: The "category" field MUST be a snake_case string (e.g. "audio_to_text", "text_to_image"). NEVER use human-readable names like "Audio to Text".
 
-## YAML Entry Format (CRITICAL)
+## YAML Entry Format (CRITICAL — VIOLATIONS WILL BREAK PRODUCTION UI)
 The "yaml_entry" field MUST follow this EXACT template with NO indentation:
 \`\`\`
 - name: {human-readable model name}
@@ -1270,13 +1270,15 @@ The "yaml_entry" field MUST follow this EXACT template with NO indentation:
   features: "({developer name}) {description of model features in Japanese}"
 \`\`\`
 
-Rules for yaml_entry:
-- MUST start with "- name: "
-- MUST contain exactly 4 fields: name, server_name, release_date, features
+Rules for yaml_entry (NON-NEGOTIABLE):
+- The FIRST line MUST be exactly "- name: " (NOT "- model: ", NOT "- model_name: ", NOT any other key). Use the literal key "name".
+- MUST contain EXACTLY these 4 keys in this order: name, server_name, release_date, features.
+- All 4 keys are REQUIRED. Never omit any of them — not even if information is missing. If unknown, write "(調査中)" for features.
 - server_name MUST be exactly: ${serverName}
-- release_date MUST use Japanese date format: YYYY年M月D日 without zero-padding (e.g. 2026年1月5日, not 2026年01月05日). Use YYYY年M月頃 / YYYY年中頃 if partially unknown
-- features MUST be a double-quoted string starting with "({developer name}) " followed by a Japanese description
-- Do NOT add any extra fields (publisher, model_name, model_type, url, description, etc.)
+- release_date MUST use Japanese date format: YYYY年M月D日 without zero-padding (e.g. 2026年1月5日, not 2026年01月05日). Use YYYY年M月頃 / YYYY年中頃 if partially unknown.
+- features MUST be a non-empty double-quoted string starting with "({developer name}) " followed by a Japanese description.
+- FORBIDDEN keys (NEVER use these as substitutes for "name", "release_date", or "features"): model, model_name, modelName, publisher, developer, model_type, url, link, description, summary, note. If you have such information, embed it inside the "features" string instead.
+- The downstream system parses YAML by exact key name. Using "model_name" or "model" instead of "name" makes the entry invisible to the search UI.
 
 ## Output JSON Schema
 {

--- a/tools/validate_model_memo.py
+++ b/tools/validate_model_memo.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""
+kamuicode_model_memo.yaml スキーマ検証スクリプト
+
+各モデルエントリが以下を満たすことをチェック:
+- 必須キー: name, server_name, release_date, features
+- 禁止キー: model, model_name, modelName, publisher, developer, model_type, url, link, description, summary, note
+- 各値が非空文字列
+
+CI で実行され、違反があれば exit 1 で失敗。
+"""
+
+import sys
+from pathlib import Path
+
+import yaml
+
+REQUIRED_KEYS = ["name", "server_name", "release_date", "features"]
+FORBIDDEN_KEYS = [
+    "model",
+    "model_name",
+    "modelName",
+    "publisher",
+    "developer",
+    "model_type",
+    "url",
+    "link",
+    "description",
+    "summary",
+    "note",
+]
+
+
+def validate(yaml_path: Path) -> list[str]:
+    """YAMLを検証し、エラーメッセージのリストを返す。空リストなら成功。"""
+    errors: list[str] = []
+
+    if not yaml_path.exists():
+        return [f"File not found: {yaml_path}"]
+
+    try:
+        with yaml_path.open(encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    except yaml.YAMLError as e:
+        return [f"YAML parse error: {e}"]
+
+    if not isinstance(data, dict):
+        return ["Root must be a mapping"]
+
+    ai_models = data.get("ai_models")
+    if not isinstance(ai_models, dict):
+        return ["'ai_models' key missing or not a mapping"]
+
+    for category, models in ai_models.items():
+        if not isinstance(models, list):
+            errors.append(f"Category '{category}': value must be a list")
+            continue
+
+        for idx, model in enumerate(models):
+            if not isinstance(model, dict):
+                errors.append(f"Category '{category}' [#{idx}]: entry must be a mapping")
+                continue
+
+            label = f"Category '{category}' [#{idx}]"
+            server_name = model.get("server_name", "<no server_name>")
+            label_with_server = f"{label} server_name='{server_name}'"
+
+            # 必須キーチェック
+            for key in REQUIRED_KEYS:
+                if key not in model:
+                    errors.append(f"{label_with_server}: missing required key '{key}'")
+                else:
+                    value = model[key]
+                    if value is None or (isinstance(value, str) and not value.strip()):
+                        errors.append(f"{label_with_server}: '{key}' is empty")
+                    elif not isinstance(value, str):
+                        errors.append(
+                            f"{label_with_server}: '{key}' must be a string (got {type(value).__name__})"
+                        )
+
+            # 禁止キーチェック
+            for key in FORBIDDEN_KEYS:
+                if key in model:
+                    errors.append(
+                        f"{label_with_server}: forbidden key '{key}' found "
+                        f"(use 'features' to embed such info instead)"
+                    )
+
+    return errors
+
+
+def main() -> int:
+    repo_root = Path(__file__).parent.parent
+    yaml_path = repo_root / "kamuicode_model_memo.yaml"
+
+    if len(sys.argv) > 1:
+        yaml_path = Path(sys.argv[1])
+
+    print(f"Validating: {yaml_path}")
+    errors = validate(yaml_path)
+
+    if errors:
+        print(f"\n[FAIL] Validation FAILED: {len(errors)} error(s)\n")
+        for err in errors:
+            print(f"  - {err}")
+        return 1
+
+    print("\n[OK] Validation PASSED")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #68

## Summary
- GitHub Pages版 (docs/index.html) のテキスト絞込が `model.name` undefined エントリで TypeError → 完全停止していた問題を修正
- 原因となった YAML の3件のキー名間違いを修正
- 再発防止として Gemini プロンプト改善 + スキーマ検証 + CI を導入

## 多層防御の構成
```
プロンプトで防御 (tools/code.js)
  ↓
データ修正 (kamuicode_model_memo.yaml)
  ↓
スキーマ検証 (tools/validate_model_memo.py)
  ↓
CI でブロック (.github/workflows/validate.yml)
  ↓
HTML側もnull guardで壊れない (docs/index.html)
```

## Test plan
- [ ] `python tools/validate_model_memo.py` がローカルで PASS する（実施済み）
- [ ] PR作成後 validate.yml ワークフローが走り PASS する
- [ ] マージ後 GitHub Pages のテキスト絞込が動作する
- [ ] 試しに YAML を壊した PR を作ると CI が FAIL する

🤖 Generated with [Claude Code](https://claude.com/claude-code)