### PR TITLE
feat: 廃止モデル対応 (deprecated スキーマ + UI トグル)

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,60 @@ t2i-kamui-flux-krea-lora: false
 * ブラウザのキャッシュをクリアして再試行してください  
 * 「カスタムYAMLファイルを使用」モードに切り替えて、ローカルファイルを使用してください
 
+## **データスキーマ仕様**
+
+`kamuicode_model_memo.yaml` のスキーマは外部ツール（スキル生成ツールなど）からも利用されることを前提に、安定した形式を保つよう運用されています。
+
+### **モデルエントリの必須キー**
+
+各モデルは以下の4つのキーを必ず持ちます:
+
+| キー | 型 | 説明 |
+|---|---|---|
+| `name` | string | 人間可読のモデル名 |
+| `server_name` | string | MCPサーバーID。一意である必要があります |
+| `release_date` | string | 日本語日付 (`YYYY年M月D日`、ゼロ埋めなし)。日が不明な場合は `YYYY年M月頃` |
+| `features` | string | 開発元と機能説明 (`(開発元) 説明...` 形式) |
+
+### **`deprecated` ブロック (任意)**
+
+エンドポイント変更等で廃止になったモデルには `deprecated` ブロックを付けて、移行先を明示します。
+
+```yaml
+- name: ByteDance Seedance 2.0 Text-to-Video
+  server_name: t2v-kamui-bytedance-seedance-v20
+  release_date: 2026年2月12日
+  features: "(ByteDance) ..."
+  deprecated:
+    replaced_by: t2v-sd2-kamui-bytedance-seedance-v20
+    reason: エンドポイント変更
+```
+
+| サブキー | 型 | 説明 |
+|---|---|---|
+| `replaced_by` | string | 移行先の `server_name`。YAML 内に実在し、自己参照でないこと |
+| `reason` | string | 廃止理由（短い説明） |
+
+`deprecated` ブロックの存在は CI バリデーター (`tools/validate_model_memo.py`) によって検証されます。
+
+### **外部ツールでの参照例**
+
+スキル生成等の外部ツール側では、以下のように `deprecated` を見て新エンドポイントへ自動置換、またはスキップ等の処理を行えます。
+
+```python
+import yaml
+
+with open('kamuicode_model_memo.yaml', encoding='utf-8') as f:
+    data = yaml.safe_load(f)
+
+for category, models in data['ai_models'].items():
+    for model in models:
+        if 'deprecated' in model:
+            new_id = model['deprecated']['replaced_by']
+            print(f"{model['server_name']} -> {new_id}")
+            # 旧IDを使っていたら新IDへ置換、もしくはスキップ
+```
+
 ## **ライセンス**
 
 このプロジェクトの詳細については、リポジトリのライセンスファイルを参照してください。

--- a/docs/index.html
+++ b/docs/index.html
@@ -73,8 +73,15 @@
                     </div>
                 </div>
 
-                <div class="mt-3 flex justify-end text-xs text-slate-500 font-mono">
-                    Hit: <span id="hit-count" class="font-bold text-slate-700 mx-1">0</span> models
+                <div class="mt-3 flex justify-between items-center text-xs">
+                    <label class="flex items-center gap-2 text-slate-600 cursor-pointer select-none">
+                        <input type="checkbox" id="show-deprecated"
+                               class="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500">
+                        <span>廃止モデルも表示</span>
+                    </label>
+                    <span class="text-slate-500 font-mono">
+                        Hit: <span id="hit-count" class="font-bold text-slate-700 mx-1">0</span> models
+                    </span>
                 </div>
             </div>
 
@@ -154,6 +161,7 @@
         const searchInput = document.getElementById('search-input');
         const categorySelect = document.getElementById('category-select');
         const periodSelect = document.getElementById('period-select');
+        const showDeprecatedToggle = document.getElementById('show-deprecated');
 
         // カテゴリ表示名を取得
         function getCategoryDisplayName(key) {
@@ -165,8 +173,13 @@
             const query = searchInput.value.toLowerCase();
             const category = categorySelect.value;
             const period = periodSelect.value;
+            const showDeprecated = showDeprecatedToggle.checked;
 
             return allModels.filter(model => {
+                // 廃止モデル: トグル OFF なら除外
+                if (model.deprecated && !showDeprecated) {
+                    return false;
+                }
                 const matchesCategory = category === '' || model.category === category;
                 const matchesPeriod = period === '' || (model.release_date && model.release_date.includes(period));
                 const matchesSearch = query === '' ||
@@ -187,8 +200,25 @@
                      このモデルに関連付けられたMCPツール定義は見つかりませんでした。
                    </div>`;
 
+            const isDeprecated = !!model.deprecated;
+            const deprecatedBadge = isDeprecated
+                ? `<span class="px-2.5 py-0.5 text-xs font-semibold rounded-full bg-red-50 text-red-700 border border-red-200">廃止</span>`
+                : '';
+            const deprecatedNotice = isDeprecated
+                ? `
+                    <div class="mb-6 p-4 rounded-lg border border-red-200 bg-red-50 text-sm text-red-800">
+                        <p class="font-bold mb-1">⚠️ ${model.deprecated.reason || '廃止'}のため廃止</p>
+                        <p>新しいエンドポイントをご利用ください:</p>
+                        <code class="inline-block mt-1 px-2 py-0.5 bg-white border border-red-200 rounded text-xs font-mono select-all text-red-900">${model.deprecated.replaced_by || ''}</code>
+                    </div>`
+                : '';
+            const nameClass = isDeprecated
+                ? 'text-lg font-bold text-slate-500 truncate line-through'
+                : 'text-lg font-bold text-indigo-700 truncate';
+            const cardOpacity = isDeprecated ? 'opacity-75' : '';
+
             return `
-                <div class="group bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden hover:shadow-md transition-all duration-200">
+                <div class="group bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden hover:shadow-md transition-all duration-200 ${cardOpacity}">
                     <div class="model-header p-6 cursor-pointer flex items-start gap-4 hover:bg-slate-50 transition-colors relative" data-server="${model.server_name}">
                         <div class="flex-shrink-0 mt-1">
                             <div class="w-10 h-10 rounded-full flex items-center justify-center transition-colors ${model.hasCatalog ? 'bg-green-100 text-green-600' : 'bg-gray-100 text-gray-400'}">
@@ -199,11 +229,12 @@
                             <div class="flex flex-wrap items-center gap-2 mb-1.5">
                                 <span class="px-2.5 py-0.5 text-xs font-semibold rounded-full bg-slate-100 text-slate-600 border border-slate-200">${getCategoryDisplayName(model.category)}</span>
                                 ${model.tools.length > 0 ? `<span class="px-2.5 py-0.5 text-xs font-semibold rounded-full bg-indigo-50 text-indigo-600 border border-indigo-100">${model.tools.length} Tools</span>` : ''}
+                                ${deprecatedBadge}
                                 <span class="text-xs font-mono text-slate-500 flex items-center gap-1 bg-slate-50 px-2 py-0.5 rounded border border-slate-100">
                                     📅 ${model.release_date || '不明'}
                                 </span>
                             </div>
-                            <h3 class="text-lg font-bold text-indigo-700 truncate">${model.name}</h3>
+                            <h3 class="${nameClass}">${model.name}</h3>
                             <div class="text-xs font-mono text-slate-500 bg-slate-100 px-2 py-0.5 rounded inline-block mt-1 select-all border border-slate-200">${model.server_name}</div>
                         </div>
                         <div class="text-slate-400 group-hover:text-indigo-500 transition-colors pt-2">
@@ -215,6 +246,7 @@
                     <div class="model-details ${isExpanded ? '' : 'hidden'}">
                         <div class="px-6 pb-8 pt-0">
                             <div class="border-t border-dashed border-gray-200 my-4"></div>
+                            ${deprecatedNotice}
                             <div class="mb-8">
                                 <h4 class="text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">概要</h4>
                                 <p class="text-sm text-slate-800 leading-relaxed bg-slate-50 p-4 rounded-lg border border-slate-100">${model.features || ''}</p>
@@ -434,6 +466,7 @@
                 searchInput.addEventListener('input', renderModels);
                 categorySelect.addEventListener('change', renderModels);
                 periodSelect.addEventListener('change', renderModels);
+                showDeprecatedToggle.addEventListener('change', renderModels);
 
                 // 表示を切り替え
                 loadingEl.classList.add('hidden');

--- a/kamuicode-config-manager.html
+++ b/kamuicode-config-manager.html
@@ -91,6 +91,7 @@
                 // --- フィルタとオプション ---
                 filterCategory: '',
                 filterText: '',
+                showDeprecated: false,  // 廃止モデルを表示するか
 
                 // 出力ファイル名を変更
                 outputFileName: 'mcp-kamui-code-filtered',
@@ -499,12 +500,13 @@
                             sortableDate = this.parseDate(yamlDetails.release_date); // 日付をパース
                             // YAMLに情報がある場合
                             this.masterList.push({
-                                checked: true,
+                                checked: !yamlDetails.deprecated, // 廃止モデルは初期OFF
                                 server_name: serverName,
                                 category: yamlDetails.category,
                                 name: yamlDetails.name,
                                 release_date: yamlDetails.release_date,
                                 features: yamlDetails.features,
+                                deprecated: yamlDetails.deprecated || null,
                                 sortable_date: sortableDate, // ソート用日付を追加
                                 server_info: serverInfo,
                                 source_file: sourceFile
@@ -593,9 +595,14 @@
                 applyFilters() {
                     const category = this.filterCategory;
                     const text = this.filterText.toLowerCase();
+                    const showDeprecated = this.showDeprecated;
 
                     // フィルタリング (この時点では masterList の順序 = JSON順)
                     this.filteredList = this.masterList.filter(model => {
+                        // 廃止モデル: トグル OFF なら除外
+                        if (model.deprecated && !showDeprecated) {
+                            return false;
+                        }
                         const categoryMatch = !category || model.category === category;
                         const textMatch = !text ||
                                           (model.name && model.name.toLowerCase().includes(text)) ||
@@ -1560,6 +1567,14 @@
                         </div>
                     </div>
 
+                    <!-- 廃止モデル表示トグル -->
+                    <div class="mt-3">
+                        <label class="inline-flex items-center cursor-pointer select-none">
+                            <input type="checkbox" x-model="showDeprecated" @change="applyFilters" class="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500">
+                            <span class="ml-2 text-sm text-gray-700">廃止モデルも表示</span>
+                        </label>
+                    </div>
+
                     <hr class="my-4 border-gray-200">
 
                     <!-- 一括チェック/解除ボタン と ソート解除 -->
@@ -1641,15 +1656,29 @@
                                 </tr>
                             </template>
                             <template x-for="model in filteredList" :key="model.server_name">
-                                <tr class="hover:bg-gray-50">
+                                <tr :class="model.deprecated ? 'bg-red-50/30 hover:bg-red-50' : 'hover:bg-gray-50'">
                                     <td class="px-4 py-4 text-center">
                                         <!-- masterList の状態を直接トグルする -->
                                         <input type="checkbox" x-model="masterList.find(m => m.server_name === model.server_name).checked" class="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500">
+                                        <template x-if="model.deprecated && masterList.find(m => m.server_name === model.server_name).checked">
+                                            <div class="mt-1 text-[10px] text-red-700 font-bold" title="廃止モデルが選択されています">⚠️</div>
+                                        </template>
                                     </td>
                                     <td class="px-4 py-4 text-sm text-gray-600" x-text="model.category"></td>
-                                    <td class="px-4 py-4 text-sm font-medium text-gray-900">
-                                        <span x-text="model.name"></span>
-                                        <span class="block text-xs text-gray-400" x-text="model.server_name"></span>
+                                    <td class="px-4 py-4 text-sm font-medium">
+                                        <div class="flex items-center gap-2 flex-wrap">
+                                            <span :class="model.deprecated ? 'text-gray-500 line-through' : 'text-gray-900'" x-text="model.name"></span>
+                                            <template x-if="model.deprecated">
+                                                <span class="px-2 py-0.5 text-[10px] font-semibold rounded-full bg-red-100 text-red-700 border border-red-200">廃止</span>
+                                            </template>
+                                        </div>
+                                        <span class="block text-xs text-gray-400 mt-0.5" x-text="model.server_name"></span>
+                                        <template x-if="model.deprecated">
+                                            <div class="mt-2 p-2 rounded border border-red-200 bg-red-50 text-xs text-red-800">
+                                                <p class="font-bold">⚠️ <span x-text="model.deprecated.reason || '廃止'"></span>のため廃止</p>
+                                                <p class="mt-1">→ <code class="px-1 py-0.5 bg-white border border-red-200 rounded font-mono text-red-900 select-all" x-text="model.deprecated.replaced_by"></code> を使用してください</p>
+                                            </div>
+                                        </template>
                                     </td>
                                     <td class="px-4 py-4 text-sm text-gray-600" x-text="model.release_date"></td>
                                     <!-- ソース列 (副JSONがある場合のみ表示) -->

--- a/kamuicode_model_memo.yaml
+++ b/kamuicode_model_memo.yaml
@@ -774,10 +774,16 @@ ai_models:
       server_name: t2v-kamui-bytedance-seedance-v20
       release_date: 2026年2月12日
       features: "(ByteDance) テキストプロンプトからシネマティックな高品質動画をネイティブな音声付きで生成できる、統合マルチモーダル動画生成モデル。高度な物理法則の再現やカメラコントロール機能を備え、最大15秒の動画生成に対応する。"
+      deprecated:
+        replaced_by: t2v-sd2-kamui-bytedance-seedance-v20
+        reason: エンドポイント変更
     - name: Seedance 2.0 Fast
       server_name: t2v-kamui-bytedance-seedance-v20-fast
       release_date: 2026年2月12日
       features: "(ByteDance) テキストプロンプトから最大15秒のシネマティックな動画を高速で生成するモデル。物理法則に基づくリアルな動きの再現や、映像と同期したネイティブな音声の生成に対応している。"
+      deprecated:
+        replaced_by: t2v-sd2-kamui-bytedance-seedance-v20-fast
+        reason: エンドポイント変更
     - name: PixVerse C1 Text-to-Video
       server_name: t2v-kamui-pixverse-c1
       release_date: 2026年4月7日
@@ -1051,10 +1057,16 @@ ai_models:
       server_name: i2v-kamui-bytedance-seedance-v20-fast
       release_date: 2026年2月12日
       features: "(ByteDance) ByteDanceによるSeedance 2.0の高速な画像生成ビデオ（Image-to-Video）モデル。元画像とプロンプトから、実世界の物理法則を反映したシネマティックで高品質な動画をネイティブな音声付きで生成可能。解像度は480p/720p、生成時間は4〜15秒に対応。"
+      deprecated:
+        replaced_by: i2v-sd2-kamui-bytedance-seedance-v20-fast
+        reason: エンドポイント変更
     - name: Seedance 2.0 Image-to-Video
       server_name: i2v-kamui-bytedance-seedance-v20
       release_date: 2026年2月12日
       features: "(ByteDance) ByteDanceが開発した動画生成AI「Seedance 2.0」のImage-to-Videoモデル。参照画像とプロンプトから、物理法則に準拠した自然な動きやネイティブな音声同期を伴う最大15秒の高品質なシネマティック動画を生成できる。開始・終了画像の指定、解像度（480p/720p）の選択、アスペクト比の調整など、高度なコントロール機能を備える。"
+      deprecated:
+        replaced_by: i2v-sd2-kamui-bytedance-seedance-v20
+        reason: エンドポイント変更
     - name: PixVerse C1 Transition
       server_name: start-end-kamui-pixverse-c1-transition
       release_date: 2026年4月7日
@@ -1389,10 +1401,16 @@ ai_models:
       server_name: r2v-kamui-bytedance-seedance-v20-reference
       release_date: 2026年2月12日
       features: "(ByteDance) 最大9枚の画像、3つの動画、3つの音声を参照用入力として組み合わせ、指定した構図や動き、カメラワークなどを反映させた動画を生成できるReference-to-Videoモデル。物理法則に忠実な動きとネイティブオーディオの同時生成が可能で、高い映像制御能力を持ちます。"
+      deprecated:
+        replaced_by: r2v-sd2-kamui-bytedance-seedance-v20-reference
+        reason: エンドポイント変更
     - name: ByteDance Seedance 2.0 Fast Reference-to-Video
       server_name: r2v-kamui-bytedance-seedance-v20-fast-reference
       release_date: 2026年2月12日
       features: "(ByteDance) 最大9枚の画像、3つの動画、3つの音声とテキストを組み合わせて入力でき、ネイティブ音声と同期したシネマティックな動画を最大15秒まで高速生成するReference-to-Videoモデル。"
+      deprecated:
+        replaced_by: r2v-sd2-kamui-bytedance-seedance-v20-fast-reference
+        reason: エンドポイント変更
     - name: Pixverse C1 Reference-to-Video
       server_name: r2v-kamui-pixverse-c1
       release_date: 2026年4月7日

--- a/tools/code.js
+++ b/tools/code.js
@@ -1279,6 +1279,7 @@ Rules for yaml_entry (NON-NEGOTIABLE):
 - features MUST be a non-empty double-quoted string starting with "({developer name}) " followed by a Japanese description.
 - FORBIDDEN keys (NEVER use these as substitutes for "name", "release_date", or "features"): model, model_name, modelName, publisher, developer, model_type, url, link, description, summary, note. If you have such information, embed it inside the "features" string instead.
 - The downstream system parses YAML by exact key name. Using "model_name" or "model" instead of "name" makes the entry invisible to the search UI.
+- Do NOT add a "deprecated" key to your output. The "deprecated" key is reserved for manual annotation when an endpoint is retired. If a model is genuinely retired with a known replacement, mention it in features instead (e.g. "(ByteDance) ... ※新エンドポイント xxx-sd2-xxx を推奨").
 
 ## Output JSON Schema
 {

--- a/tools/validate_model_memo.py
+++ b/tools/validate_model_memo.py
@@ -6,6 +6,10 @@ kamuicode_model_memo.yaml スキーマ検証スクリプト
 - 必須キー: name, server_name, release_date, features
 - 禁止キー: model, model_name, modelName, publisher, developer, model_type, url, link, description, summary, note
 - 各値が非空文字列
+- deprecated ブロック (任意) の構造:
+    - deprecated.replaced_by: 必須かつ YAML 内に実在する server_name (自己参照不可)
+    - deprecated.reason: 必須の非空文字列
+    - 他のキーは許容しない
 
 CI で実行され、違反があれば exit 1 で失敗。
 """
@@ -29,6 +33,64 @@ FORBIDDEN_KEYS = [
     "summary",
     "note",
 ]
+DEPRECATED_REQUIRED_KEYS = ["replaced_by", "reason"]
+DEPRECATED_ALLOWED_KEYS = {"replaced_by", "reason"}
+
+
+def collect_server_names(ai_models: dict) -> set[str]:
+    """全エントリの server_name を集める"""
+    names: set[str] = set()
+    for models in ai_models.values():
+        if isinstance(models, list):
+            for model in models:
+                if isinstance(model, dict):
+                    sn = model.get("server_name")
+                    if isinstance(sn, str) and sn:
+                        names.add(sn)
+    return names
+
+
+def validate_deprecated_block(
+    deprecated, label: str, own_server_name: str, all_server_names: set[str]
+) -> list[str]:
+    """deprecated ブロックを検証"""
+    errors: list[str] = []
+
+    if not isinstance(deprecated, dict):
+        return [f"{label}: 'deprecated' must be a mapping"]
+
+    # 必須キー
+    for key in DEPRECATED_REQUIRED_KEYS:
+        if key not in deprecated:
+            errors.append(f"{label}: 'deprecated.{key}' is required")
+            continue
+        value = deprecated[key]
+        if not isinstance(value, str) or not value.strip():
+            errors.append(f"{label}: 'deprecated.{key}' must be a non-empty string")
+
+    # 想定外キー
+    extra_keys = set(deprecated.keys()) - DEPRECATED_ALLOWED_KEYS
+    if extra_keys:
+        errors.append(
+            f"{label}: 'deprecated' has unknown key(s): {sorted(extra_keys)} "
+            f"(allowed: {sorted(DEPRECATED_ALLOWED_KEYS)})"
+        )
+
+    # replaced_by の参照先存在確認 + 自己参照禁止
+    replaced_by = deprecated.get("replaced_by")
+    if isinstance(replaced_by, str) and replaced_by.strip():
+        if replaced_by == own_server_name:
+            errors.append(
+                f"{label}: 'deprecated.replaced_by' must not be a self-reference "
+                f"('{replaced_by}')"
+            )
+        elif replaced_by not in all_server_names:
+            errors.append(
+                f"{label}: 'deprecated.replaced_by' references unknown server_name "
+                f"'{replaced_by}'"
+            )
+
+    return errors
 
 
 def validate(yaml_path: Path) -> list[str]:
@@ -50,6 +112,8 @@ def validate(yaml_path: Path) -> list[str]:
     ai_models = data.get("ai_models")
     if not isinstance(ai_models, dict):
         return ["'ai_models' key missing or not a mapping"]
+
+    all_server_names = collect_server_names(ai_models)
 
     for category, models in ai_models.items():
         if not isinstance(models, list):
@@ -85,6 +149,15 @@ def validate(yaml_path: Path) -> list[str]:
                         f"{label_with_server}: forbidden key '{key}' found "
                         f"(use 'features' to embed such info instead)"
                     )
+
+            # deprecated ブロックチェック (任意)
+            if "deprecated" in model:
+                own_sn = server_name if isinstance(server_name, str) else ""
+                errors.extend(
+                    validate_deprecated_block(
+                        model["deprecated"], label_with_server, own_sn, all_server_names
+                    )
+                )
 
     return errors
 


### PR DESCRIPTION
Closes #70

## Summary
- ByteDance Seedance 2.0 旧エンドポイント6件を `deprecated` ブロックで明示
- 両HTMLにトグル付き廃止モデル表示機能を追加 (デフォルト OFF、ON時はバッジ＋取り消し線＋移行先案内)
- バリデーターを拡張し、deprecated ブロックの整合性 (replaced_by 実在/自己参照禁止) を CI で検証
- Gemini プロンプトに deprecated キー生成禁止ルールを追加
- README に外部ツール向けのスキーマ仕様を文書化

## Test plan
- [x] `python tools/validate_model_memo.py` がローカルで PASS
- [x] 意図的に YAML を壊して FAIL することを確認 (ローカルで4種のエラー検出を確認済み)
- [ ] CI の validate ワークフローが PASS
- [ ] GitHub Pages: トグル OFF/ON で旧6件の表示/非表示が切り替わる
- [ ] GitHub Pages: 表示時にバッジ + 取り消し線 + 移行先案内が出る
- [ ] ローカル HTML: 同様に動作、廃止モデルの初期チェックが OFF
- [ ] ローカル HTML: 廃止モデルにチェック入れると警告が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)