### PR TITLE
chore: redact KAMUI_CODE_PASS_KEY length from workflow logs

### DIFF
--- a/.github/workflows/update_catalog.yml
+++ b/.github/workflows/update_catalog.yml
@@ -64,11 +64,12 @@ jobs:
         run: |
           cd tools/crawler
 
-          # Debug: Check if KAMUI_CODE_PASS_KEY is set (show length only, not the value)
-          if [ -n "$KAMUI_CODE_PASS_KEY" ]; then
-            echo "✅ KAMUI_CODE_PASS_KEY is set (length: ${#KAMUI_CODE_PASS_KEY} chars)"
+          # Check if KAMUI_CODE_PASS_KEY is configured (presence only, no metadata)
+          if [ -n "${KAMUI_CODE_PASS_KEY:-}" ]; then
+            echo "✅ KAMUI_CODE_PASS_KEY is configured"
           else
-            echo "❌ KAMUI_CODE_PASS_KEY is NOT set or empty!"
+            echo "❌ KAMUI_CODE_PASS_KEY is NOT configured"
+            exit 1
           fi
 
           # Build options


### PR DESCRIPTION
## Summary

Replace the workflow log line that exposes the byte length of `KAMUI_CODE_PASS_KEY` with a presence-only check.

## Reasons

- The previous `length: N chars` output is metadata leakage that **GitHub Actions' value-masking does not catch** — masking applies to the literal secret value, not to derived data such as `${#var}`.
- For ~5 months (since 2025-12-26), the byte length and `is set / not set` state of the active key were written to public workflow run logs.
- The owner already rotated the key on 2026-04-06 for unrelated reasons, but the length echo continued to expose length of the new value as well — so the right fix is to stop emitting it going forward, regardless of rotation history.

## Risk assessment

- The actual secret value was always masked → **no direct credential leak**.
- Length disclosure reduces brute-force search space and helps format inference (e.g. "32 chars → likely Base64(24 bytes) or UUID").
- Standalone risk is low, but the fix has near-zero cost so it is worth applying.

## Changes

- Replace `length: ${#KAMUI_CODE_PASS_KEY} chars` echo with a presence-only check.
- Fail fast (`exit 1`) when the secret is not configured, so a missing secret is loud instead of silent.
- Use `${VAR:-}` to be safe under `set -u` (in case strict mode is enabled later).
- No functional change to the crawler step itself.

## Test plan

- [ ] `Update MCP Tool Catalog` workflow still passes the secret check step with the secret configured.
- [ ] A future workflow run no longer contains the substring `length:` near `KAMUI_CODE_PASS_KEY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)